### PR TITLE
Remove doctest from JWK.GoogleTest

### DIFF
--- a/test/lib/kitten_blue/jwk/google_test.exs
+++ b/test/lib/kitten_blue/jwk/google_test.exs
@@ -1,6 +1,5 @@
 defmodule KittenBlue.JWK.GoogleTest do
   use ExUnit.Case
-  doctest KittenBlue.JWK.Google
 
   import Mock
 


### PR DESCRIPTION
Doctest causes test failure since it will send real HTTP requests to get Google Public JWKs
(mocks are enabled only on "fetch!" test of JWK.GoogleTest by dynamic mocking)

I think we should be configurable the HTTP client by config or somewhere to inject mock module, rather than using dynamic mocking.
But for now, I'll simply remove doctest.

## Test Failure
```shell
$ mix test
Compiling 3 files (.ex)
Generated kitten_blue app
..........

  1) doctest KittenBlue.JWK.Google.fetch!/0 (1) (KittenBlue.JWK.GoogleTest)
     test/lib/kitten_blue/jwk/google_test.exs:3
     Doctest failed
     code: KittenBlue.JWK.Google.fetch!() === [
             %KittenBlue.JWK{
               alg: "RS256",
               key: %JOSE.JWK{
                 fields: %{
                   "alg" => "RS256",
                   "kid" => "4ef5118b0800bd60a4194186dcb538fc66e5eb34",
                   "use" => "sig"
                 },
                 keys: :undefined,
                 kty: {:jose_jwk_kty_rsa,
                   {:RSAPublicKey,
                   28476875648721430364188748069991806407446391450373045237923762311151009162921226253790824442505385585760732916607116438838248229723204601135715042657593479636219565745251068995383455309324246029645697720081638829054979172310837551569227970489185383795840331251273817798301830005422761396312919579380879507526326553332110468129972850911213822427291482233788412930127022336316623384602807587333085533862008937303422811962712539911685812228824633770949283643459223554618469656343403152537435626750336345544118558104593194249902094334930123144035611712340631611229262692299252575582560206205278645742069502946607521835099,
                   65537}}
               },
               kid: "4ef5118b0800bd60a4194186dcb538fc66e5eb34"
             },
             %KittenBlue.JWK{
               alg: "RS256",
               key: %JOSE.JWK{
                 fields: %{
                   "alg" => "RS256",
                   "kid" => "4129db2ea1860d2e871ee48506287fb05b04ca3f",
                   "use" => "sig"
                 },
                 keys: :undefined,
                 kty: {:jose_jwk_kty_rsa,
                   {:RSAPublicKey,
                   22609561106030035864482994811877141824726126803777462187648248944200098073331236741294232586553300034895012108018434924729133961311183119141914600651954926309301332274897870471122898299742307430511282554878657777308136016225973120369034252221550856774547365225662288681658668758322854479413570330389061522515472701665508175326183008659994223993772082779679322909193619920243402323372013460399491079488825891466897860506499022502474569809346311328649517115778556011555295770068761196334945203754564406086391916223828979710434236708178064890005597548004735093378516718512005576664304324911503655030914082941717001104327,
                   65537}}
               },
               kid: "4129db2ea1860d2e871ee48506287fb05b04ca3f"
             }
           ]
     left: [
             %KittenBlue.JWK{
               alg: "RS256",
               key: %JOSE.JWK{
                 fields: %{
                   "alg" => "RS256",
                   "kid" => "60cd3771c1125c9f77e82e39974e163a8c73b3c4",
                   "use" => "sig"
                 },
                 keys: :undefined,
                 kty: {:jose_jwk_kty_rsa,
                  {:RSAPublicKey,
                   24132131976928119739065215966635572234663275981330765058678961234447638491407260153464871117172758058625587533975819196211009573454050480576141990978657542485125305136376732526235966540230148848851999801966646035779310022177223807518823659524690445838294476894853801580210279675373384532192953004966396832989304546328198408206244103825020722238698190458403154911956413722602117005825022452367706843119694308756426315801662590749436372990169879891589994676692588382690384891625753470718264513309292200033592311686513500976816388666850064563472766000389500960661388338524642008790415093704805138187146743782509662498333,
                   65537}}
               },
               kid: "60cd3771c1125c9f77e82e39974e163a8c73b3c4"
             },
             %KittenBlue.JWK{
               alg: "RS256",
               key: %JOSE.JWK{
                 fields: %{
                   "alg" => "RS256",
                   "kid" => "463fe480c3c5839bbb15861e08c32d187faf9a56",
                   "use" => "sig"
                 },
                 keys: :undefined,
                 kty: {:jose_jwk_kty_rsa,
                  {:RSAPublicKey,
                   23885325192459562476935083497417882230809729047801475612990081846018274141498450978967977038322629447198024799939398275485655795671732313309734403288652483676120226591630875928029705377814224535509080709587284028333401302814411674797875787304328520952050746054945629247317914426841381411848669978157845640598966580325647666823128657091018889112113803543141976780071487879203082138343810447208447346642846079822211652773338836957263083875395549984042084918191248831312385707252355997919999643916867537004677389398155846381681886513130893637461275913304660539585058469791432652377886033872301738954844035987204788626093,
                   65537}}
               },
               kid: "463fe480c3c5839bbb15861e08c32d187faf9a56"
             }
           ]
     stacktrace:
       lib/kitten_blue/jwk/google.ex:16: KittenBlue.JWK.Google (module)



Finished in 0.4 seconds
1 doctest, 10 tests, 1 failure

Randomized with seed 182666
```