### PR TITLE
Make jwk config to optional (version 0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.0
+
+* Make the configuration for KittenBlue.JWK optional.
+
+## 0.4.0
+
+* Good bye travis, and hello actions
+
 ## 0.3.0
 
 * Use Scratcher to remove dependency on HTTPoison

--- a/lib/kitten_blue/jwk.ex
+++ b/lib/kitten_blue/jwk.ex
@@ -13,7 +13,14 @@ defmodule KittenBlue.JWK do
 
   @type t :: %__MODULE__{kid: String.t(), alg: String.t(), key: JOSE.JWK.t()}
 
-  @http_client Application.fetch_env!(:kitten_blue, __MODULE__) |> Keyword.fetch!(:http_client)
+  # Set the default value here to avoid compilation errors where Configuration does not exist.
+  @http_client (case(Application.fetch_env(:kitten_blue, __MODULE__)) do
+                  {:ok, config} ->
+                    config |> Keyword.fetch!(:http_client)
+
+                  _ ->
+                    Scratcher.HttpClient
+                end)
 
   # NOTE: from_compact/to_conpact does not support Poly1305
   @algs_for_oct ["HS256", "HS384", "HS512"]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule KittenBlue.Mixfile do
   def project do
     [
       app: :kitten_blue,
-      version: "0.4.0",
+      version: "0.5.0",
       elixir: "~> 1.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
In version 0.4.0, Config was required for JWK.
To avoid compilation errors caused by libraries that use KittenBlue not having Config, make this optional.