### PR TITLE
Add function to verify JWS token with x5c header using JWK object

### DIFF
--- a/lib/kitten_blue/jwk/x509.ex
+++ b/lib/kitten_blue/jwk/x509.ex
@@ -1,0 +1,39 @@
+defmodule KittenBlue.JWK.X509 do
+  @moduledoc """
+  Handling JWK modules with regard to X.509
+  """
+
+  @type certificate :: X509.ASN1.record(:otp_certificate)
+
+  @doc """
+  Generate KittenBlue.JWK from JWS Token that includes X.509 Certificate Chain
+  """
+  @spec new_from_jws_token(jws_token :: String.t(), trusted_cert :: certificate()) ::
+          KittenBlue.JWK.t()
+          | {:error, :invalid_certificate}
+          | {:error, :invalid_jws_header}
+          | {:error, :invalid_jws_format}
+  def new_from_jws_token(jws_token, trusted_cert) do
+    try do
+      JOSE.JWS.peek_protected(jws_token)
+      |> Jason.decode!()
+      |> case do
+        %{"kid" => kid, "alg" => alg, "x5c" => x5c} ->
+          cert_chain = x5c |> Enum.map(&Base.decode64!/1) |> Enum.reverse()
+
+          case :public_key.pkix_path_validation(trusted_cert, cert_chain, []) do
+            {:ok, {{_, key, _}, _}} ->
+              [kid, alg, key |> JOSE.JWK.from_key()] |> KittenBlue.JWK.new()
+
+            _ ->
+              {:error, :invalid_certificate}
+          end
+        _ ->
+          {:error, :invalid_jws_header}
+      end
+    rescue
+      _ ->
+        {:error, :invalid_jws_format}
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -34,6 +34,7 @@ defmodule KittenBlue.Mixfile do
     [
       {:jose, "~> 1.11"},
       {:jason, "~> 1.2", optional: true},
+      {:x509, "~> 0.8"},
 
       # HTTP Client
       {:scratcher, "~> 0.1"},

--- a/mix.lock
+++ b/mix.lock
@@ -10,4 +10,5 @@
   "mox": {:hex, :mox, "1.0.0", "4b3c7005173f47ff30641ba044eb0fe67287743eec9bd9545e37f3002b0a9f8b", [:mix], [], "hexpm", "201b0a20b7abdaaab083e9cf97884950f8a30a1350a1da403b3145e213c6f4df"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
   "scratcher": {:hex, :scratcher, "0.1.1", "50ae0170c7564b81fc491dc8f7ed195371586df9e2f2d7981685815c2187c54b", [:mix], [], "hexpm", "0e83bef9c7f41d16bf196ca83e4798b9bf7b031fcb0ea5f4e2ba612f89352845"},
+  "x509": {:hex, :x509, "0.8.5", "22b2c5dfc87b05d46595d3764f41a23fcb7360f891e0464f1a2ec118177cd4e4", [:mix], [], "hexpm", "c63eb89e8bbe8a5e21b6404ad1082faff670e38b74960297f90d023177949e07"},
 }

--- a/test/lib/kitten_blue/jwk/x509_test.exs
+++ b/test/lib/kitten_blue/jwk/x509_test.exs
@@ -1,4 +1,4 @@
-defmodule KittenBlue.Jwk.X509Test do
+defmodule KittenBlue.JWK.X509Test do
   use ExUnit.Case
 
   alias KittenBlue.JWK

--- a/test/lib/kitten_blue/jwk/x509_test.exs
+++ b/test/lib/kitten_blue/jwk/x509_test.exs
@@ -1,0 +1,113 @@
+defmodule KittenBlue.Jwk.X509Test do
+  use ExUnit.Case
+
+  alias KittenBlue.JWK
+  doctest JWK.X509
+
+  describe "new_from_jws_token" do
+    setup do
+      key = File.read!("sample_pem/rsa-2048.pem") |> X509.PrivateKey.from_pem!()
+
+      root_ca =
+        X509.Certificate.self_signed(
+          key,
+          "/C=JP/ST=Tokyo/L=Shibuya/O=Acme/CN=Root CA",
+          template: :root_ca
+        )
+
+      cert =
+        key
+        |> X509.PublicKey.derive()
+        |> X509.Certificate.new(
+          "/C=JP/ST=Tokyo/L=Shibuya/O=Acme/CN=Cert",
+          root_ca,
+          key
+        )
+
+      x5c = [cert |> X509.Certificate.to_der() |> Base.encode64()]
+
+      [key: key, root_ca: root_ca, x5c: x5c]
+    end
+
+    test "ok", %{key: key, root_ca: root_ca, x5c: x5c} do
+      alg = "RS256"
+      kid = "rs256_202301"
+
+      jws =
+        key
+        |> JOSE.JWK.from_key()
+        |> JOSE.JWS.sign(
+          %{"key" => "value"} |> Jason.encode!(),
+          %{
+            "alg" => alg,
+            "kid" => kid,
+            "x5c" => x5c
+          }
+        )
+        |> JOSE.JWS.compact()
+        |> elem(1)
+
+      %JWK{} = jwk_x509 = JWK.X509.new_from_jws_token(jws, root_ca)
+      compact = JWK.to_compact(jwk_x509)
+      assert [^kid, ^alg, jwk_public_key] = compact
+
+      jwk_public_key_pem = jwk_public_key |> X509.PublicKey.from_pem!() |> X509.PublicKey.to_pem()
+      public_key_pem = key |> X509.PublicKey.derive() |> X509.PublicKey.to_pem()
+
+      assert jwk_public_key_pem == public_key_pem
+    end
+
+    test "verify error: invalid_certificate", %{key: key, x5c: x5c} do
+      alg = "RS256"
+      kid = "rs256_202301"
+
+      jws =
+        key
+        |> JOSE.JWK.from_key()
+        |> JOSE.JWS.sign(
+          %{"key" => "value"} |> Jason.encode!(),
+          %{
+            "alg" => alg,
+            "kid" => kid,
+            "x5c" => x5c
+          }
+        )
+        |> JOSE.JWS.compact()
+        |> elem(1)
+
+      key_2 = X509.PrivateKey.new_rsa(512)
+
+      root_ca_2 =
+        X509.Certificate.self_signed(
+          key_2,
+          "/C=JP/ST=Tokyo/L=Shibuya/O=Acme/CN=Root CA",
+          template: :root_ca
+        )
+
+      assert {:error, :invalid_certificate} == JWK.X509.new_from_jws_token(jws, root_ca_2)
+    end
+
+    test "verify error: invalid_jws_header", %{key: key, root_ca: root_ca, x5c: x5c} do
+      alg = "RS256"
+
+      jws =
+        key
+        |> JOSE.JWK.from_key()
+        |> JOSE.JWS.sign(
+          %{"key" => "value"} |> Jason.encode!(),
+          %{
+            "alg" => alg,
+            "x5c" => x5c
+          }
+        )
+        |> JOSE.JWS.compact()
+        |> elem(1)
+
+      assert {:error, :invalid_jws_header} == JWK.X509.new_from_jws_token(jws, root_ca)
+    end
+
+    test "verify error: invalid_jws_format", %{root_ca: root_ca} do
+      assert {:error, :invalid_jws_format} == JWK.X509.new_from_jws_token("", root_ca)
+    end
+  end
+end

--- a/test/lib/kitten_blue/jws/x509_test.exs
+++ b/test/lib/kitten_blue/jws/x509_test.exs
@@ -1,4 +1,4 @@
-defmodule KittenBlue.Jws.X509Test do
+defmodule KittenBlue.JWS.X509Test do
   use ExUnit.Case
 
   alias KittenBlue.{JWK, JWS}

--- a/test/lib/kitten_blue/jws/x509_test.exs
+++ b/test/lib/kitten_blue/jws/x509_test.exs
@@ -1,0 +1,49 @@
+defmodule KittenBlue.Jws.X509Test do
+  use ExUnit.Case
+
+  alias KittenBlue.{JWK, JWS}
+
+  test "verify" do
+    key = File.read!("sample_pem/rsa-2048.pem") |> X509.PrivateKey.from_pem!()
+
+    root_ca =
+      X509.Certificate.self_signed(
+        key,
+        "/C=JP/ST=Tokyo/L=Shibuya/O=Acme/CN=Root CA",
+        template: :root_ca
+      )
+
+    cert =
+      key
+      |> X509.PublicKey.derive()
+      |> X509.Certificate.new(
+        "/C=JP/ST=Tokyo/L=Shibuya/O=Acme/CN=Cert",
+        root_ca,
+        key
+      )
+
+    x5c = [cert |> X509.Certificate.to_der() |> Base.encode64()]
+
+    alg = "RS256"
+    kid = "rs256_202301"
+    payload = %{"key" => "value"}
+
+    jws =
+      key
+      |> JOSE.JWK.from_key()
+      |> JOSE.JWS.sign(
+        payload |> Jason.encode!(),
+        %{
+          "alg" => alg,
+          "kid" => kid,
+          "x5c" => x5c
+        }
+      )
+      |> JOSE.JWS.compact()
+      |> elem(1)
+
+    jwk = JWK.X509.new_from_jws_token(jws, root_ca)
+
+    assert {:ok, payload} == JWS.verify(jws, [jwk])
+  end
+end


### PR DESCRIPTION
This PR adds function to be able to verify JWS tokens with x5c header.

1. Generating JWK object from JWS token with x5c header.
2. Verifying JWS token using the JWK object.
