### PR TITLE
Add an optional filed to JWK to handle X.509 parameters

### DIFF
--- a/lib/kitten_blue/jwk.ex
+++ b/lib/kitten_blue/jwk.ex
@@ -15,13 +15,8 @@ defmodule KittenBlue.JWK do
   @type t :: %__MODULE__{kid: String.t(), alg: String.t(), key: JOSE.JWK.t(), x509: KittenBlue.JWK.X509.t()}
 
   # Set the default value here to avoid compilation errors where Configuration does not exist.
-  @http_client (case(Application.fetch_env(:kitten_blue, __MODULE__)) do
-                  {:ok, config} ->
-                    config |> Keyword.fetch!(:http_client)
-
-                  _ ->
-                    Scratcher.HttpClient
-                end)
+  @http_client Application.compile_env(:kitten_blue, __MODULE__, http_client: Scratcher.HttpClient)
+               |> Keyword.fetch!(:http_client)
 
   # NOTE: from_compact/to_conpact does not support Poly1305
   @algs_for_oct ["HS256", "HS384", "HS512"]

--- a/lib/kitten_blue/jwk.ex
+++ b/lib/kitten_blue/jwk.ex
@@ -8,10 +8,11 @@ defmodule KittenBlue.JWK do
   defstruct [
     :kid,
     :alg,
-    :key
+    :key,
+    :x509 # optional
   ]
 
-  @type t :: %__MODULE__{kid: String.t(), alg: String.t(), key: JOSE.JWK.t()}
+  @type t :: %__MODULE__{kid: String.t(), alg: String.t(), key: JOSE.JWK.t(), x509: KittenBlue.JWK.X509.t()}
 
   # Set the default value here to avoid compilation errors where Configuration does not exist.
   @http_client (case(Application.fetch_env(:kitten_blue, __MODULE__)) do

--- a/lib/kitten_blue/jwk/x509.ex
+++ b/lib/kitten_blue/jwk/x509.ex
@@ -52,7 +52,13 @@ defmodule KittenBlue.JWK.X509 do
 
           case :public_key.pkix_path_validation(trusted_cert, cert_chain, []) do
             {:ok, {{_, key, _}, _}} ->
-              [kid, alg, key |> JOSE.JWK.from_key()] |> KittenBlue.JWK.new()
+              %{
+                kid: kid,
+                alg: alg,
+                key: key |> JOSE.JWK.from_key(),
+                x509: KittenBlue.JWK.X509.new([x5c: x5c])
+              }
+              |> KittenBlue.JWK.new()
 
             _ ->
               {:error, :invalid_certificate}

--- a/lib/kitten_blue/jwk/x509.ex
+++ b/lib/kitten_blue/jwk/x509.ex
@@ -51,6 +51,15 @@ defmodule KittenBlue.JWK.X509 do
           cert_chain = x5c |> Enum.map(&Base.decode64!/1) |> Enum.reverse()
 
           case :public_key.pkix_path_validation(trusted_cert, cert_chain, []) do
+            {:ok, {{_, {:ECPoint, _} = key, key_params}, _}} ->
+              %{
+                kid: kid,
+                alg: alg,
+                key: {key, key_params} |> JOSE.JWK.from_key(),
+                x509: KittenBlue.JWK.X509.new([x5c: x5c])
+              }
+              |> KittenBlue.JWK.new()
+
             {:ok, {{_, key, _}, _}} ->
               %{
                 kid: kid,

--- a/lib/kitten_blue/jwk/x509.ex
+++ b/lib/kitten_blue/jwk/x509.ex
@@ -3,7 +3,36 @@ defmodule KittenBlue.JWK.X509 do
   Handling JWK modules with regard to X.509
   """
 
+  defstruct [
+    :x5c
+  ]
+
+  @type t :: %__MODULE__{x5c: [String.t()]}
+
   @type certificate :: X509.ASN1.record(:otp_certificate)
+
+  @doc """
+  Generate KittenBlue.JWK.X509 struct
+
+  ```Elixir
+  kid = "sample_202301"
+  alg = "RS256"
+  key = JOSE.JWK.from_pem_file("rsa-2048.pem")
+
+  x5c = [cert |> X509.Certificate.to_der() |> Base.encode64()]
+  x509 = KittenBlue.JWK.X509.new([x5c: x5c])
+  kb_jwk = KittenBlue.JWK.new(%{kid: kid, alg: alg, key: key, x509: x509})
+  ```
+  """
+  @spec new(params :: Keywords.t()) :: t
+  def new(params = [x5c: _]) do
+    struct(__MODULE__, Map.new(params))
+  end
+
+  @spec new(params :: Map.t()) :: t
+  def new(params = %{x5c: _}) do
+    struct(__MODULE__, params)
+  end
 
   @doc """
   Generate KittenBlue.JWK from JWS Token that includes X.509 Certificate Chain

--- a/lib/kitten_blue/jws.ex
+++ b/lib/kitten_blue/jws.ex
@@ -101,7 +101,18 @@ defmodule KittenBlue.JWS do
   def sign(payload, key = %KittenBlue.JWK{}, header) do
     token =
       key.key
-      |> JOSE.JWT.sign(Map.merge(header, %{"alg" => key.alg, "kid" => key.kid}), payload)
+      |> JOSE.JWS.sign(
+        payload |> Jason.encode!(),
+        header |> Map.merge(%{
+          "alg" => key.alg,
+          "kid" => key.kid,
+          "x5c" => if is_nil(key.x509) do
+            nil
+          else
+            key.x509.x5c
+          end
+        })
+      )
       |> JOSE.JWS.compact()
       |> elem(1)
 

--- a/test/lib/kitten_blue/jwk/x509_test.exs
+++ b/test/lib/kitten_blue/jwk/x509_test.exs
@@ -4,7 +4,7 @@ defmodule KittenBlue.JWK.X509Test do
   alias KittenBlue.JWK
   doctest JWK.X509
 
-  describe "new_from_jws_token" do
+  describe "RS256 new_from_jws_token/2" do
     setup do
       key = File.read!("sample_pem/rsa-2048.pem") |> X509.PrivateKey.from_pem!()
 

--- a/test/lib/kitten_blue/jwk/x509_test.exs
+++ b/test/lib/kitten_blue/jwk/x509_test.exs
@@ -110,4 +110,111 @@ defmodule KittenBlue.JWK.X509Test do
       assert {:error, :invalid_jws_format} == JWK.X509.new_from_jws_token("", root_ca)
     end
   end
+
+  describe "ES256 new_from_jws_token/2" do
+    setup do
+      key = File.read!("sample_pem/ec-secp256r1-alice.pem") |> X509.PrivateKey.from_pem!()
+
+      root_ca =
+        X509.Certificate.self_signed(
+          key,
+          "/C=JP/ST=Tokyo/L=Shibuya/O=Acme/CN=Root CA",
+          template: :root_ca
+        )
+
+      cert =
+        key
+        |> X509.PublicKey.derive()
+        |> X509.Certificate.new(
+          "/C=JP/ST=Tokyo/L=Shibuya/O=Acme/CN=Cert",
+          root_ca,
+          key
+        )
+
+      x5c = [cert |> X509.Certificate.to_der() |> Base.encode64()]
+
+      [key: key, root_ca: root_ca, x5c: x5c]
+    end
+
+    test "ok", %{key: key, root_ca: root_ca, x5c: x5c} do
+      alg = "ES256"
+      kid = "es256_202301"
+
+      jws =
+        key
+        |> JOSE.JWK.from_key()
+        |> JOSE.JWS.sign(
+          %{"key" => "value"} |> Jason.encode!(),
+          %{
+            "alg" => alg,
+            "kid" => kid,
+            "x5c" => x5c
+          }
+        )
+        |> JOSE.JWS.compact()
+        |> elem(1)
+
+      %JWK{} = jwk_x509 = JWK.X509.new_from_jws_token(jws, root_ca)
+      compact = JWK.to_compact(jwk_x509)
+      assert [^kid, ^alg, jwk_public_key] = compact
+
+      jwk_public_key_pem = jwk_public_key |> X509.PublicKey.from_pem!() |> X509.PublicKey.to_pem()
+      public_key_pem = key |> X509.PublicKey.derive() |> X509.PublicKey.to_pem()
+
+      assert jwk_public_key_pem == public_key_pem
+    end
+
+    test "verify error: invalid_certificate", %{key: key, x5c: x5c} do
+      alg = "ES256"
+      kid = "es256_202301"
+
+      jws =
+        key
+        |> JOSE.JWK.from_key()
+        |> JOSE.JWS.sign(
+          %{"key" => "value"} |> Jason.encode!(),
+          %{
+            "alg" => alg,
+            "kid" => kid,
+            "x5c" => x5c
+          }
+        )
+        |> JOSE.JWS.compact()
+        |> elem(1)
+
+      key_2 = X509.PrivateKey.new_rsa(512)
+
+      root_ca_2 =
+        X509.Certificate.self_signed(
+          key_2,
+          "/C=JP/ST=Tokyo/L=Shibuya/O=Acme/CN=Root CA",
+          template: :root_ca
+        )
+
+      assert {:error, :invalid_certificate} == JWK.X509.new_from_jws_token(jws, root_ca_2)
+    end
+
+    test "verify error: invalid_jws_header", %{key: key, root_ca: root_ca, x5c: x5c} do
+      alg = "ES256"
+
+      jws =
+        key
+        |> JOSE.JWK.from_key()
+        |> JOSE.JWS.sign(
+          %{"key" => "value"} |> Jason.encode!(),
+          %{
+            "alg" => alg,
+            "x5c" => x5c
+          }
+        )
+        |> JOSE.JWS.compact()
+        |> elem(1)
+
+      assert {:error, :invalid_jws_header} == JWK.X509.new_from_jws_token(jws, root_ca)
+    end
+
+    test "verify error: invalid_jws_format", %{root_ca: root_ca} do
+      assert {:error, :invalid_jws_format} == JWK.X509.new_from_jws_token("", root_ca)
+    end
+  end
 end

--- a/test/lib/kitten_blue/jws/x509_test.exs
+++ b/test/lib/kitten_blue/jws/x509_test.exs
@@ -3,86 +3,47 @@ defmodule KittenBlue.JWS.X509Test do
 
   alias KittenBlue.{JWK, JWS}
 
-  test "sign" do
-    key = File.read!("sample_pem/rsa-2048.pem") |> X509.PrivateKey.from_pem!()
+  describe "sign and verify" do
+    test "RS256" do
+      key = File.read!("sample_pem/rsa-2048.pem") |> X509.PrivateKey.from_pem!()
 
-    root_ca =
-      X509.Certificate.self_signed(
-        key,
-        "/C=JP/ST=Tokyo/L=Shibuya/O=Acme/CN=Root CA",
-        template: :root_ca
-      )
+      root_ca =
+        X509.Certificate.self_signed(
+          key,
+          "/C=JP/ST=Tokyo/L=Shibuya/O=Acme/CN=Root CA",
+          template: :root_ca
+        )
 
-    cert =
-      key
-      |> X509.PublicKey.derive()
-      |> X509.Certificate.new(
-        "/C=JP/ST=Tokyo/L=Shibuya/O=Acme/CN=Cert",
-        root_ca,
+      cert =
         key
-      )
+        |> X509.PublicKey.derive()
+        |> X509.Certificate.new(
+          "/C=JP/ST=Tokyo/L=Shibuya/O=Acme/CN=Cert",
+          root_ca,
+          key
+        )
 
-    x5c = [cert |> X509.Certificate.to_der() |> Base.encode64()]
+      x5c = [cert |> X509.Certificate.to_der() |> Base.encode64()]
 
-    alg = "RS256"
-    kid = "rs256_202301"
+      alg = "RS256"
+      kid = "rs256_202301"
 
-    jwk = %{
-      kid: kid,
-      alg: alg,
-      key: key |> JOSE.JWK.from_key(),
-      x509: JWK.X509.new([x5c: x5c])
-    }
-    |> JWK.new()
-
-    payload = %{"key" => "value"}
-
-    assert {:ok, jws} = JWS.sign(payload, jwk)
-
-    assert {:ok, payload} == JWS.verify(jws, [jwk])
-  end
-
-  test "verify" do
-    key = File.read!("sample_pem/rsa-2048.pem") |> X509.PrivateKey.from_pem!()
-
-    root_ca =
-      X509.Certificate.self_signed(
-        key,
-        "/C=JP/ST=Tokyo/L=Shibuya/O=Acme/CN=Root CA",
-        template: :root_ca
-      )
-
-    cert =
-      key
-      |> X509.PublicKey.derive()
-      |> X509.Certificate.new(
-        "/C=JP/ST=Tokyo/L=Shibuya/O=Acme/CN=Cert",
-        root_ca,
-        key
-      )
-
-    x5c = [cert |> X509.Certificate.to_der() |> Base.encode64()]
-
-    alg = "RS256"
-    kid = "rs256_202301"
-    payload = %{"key" => "value"}
-
-    jws =
-      key
-      |> JOSE.JWK.from_key()
-      |> JOSE.JWS.sign(
-        payload |> Jason.encode!(),
+      jwk =
         %{
-          "alg" => alg,
-          "kid" => kid,
-          "x5c" => x5c
+          kid: kid,
+          alg: alg,
+          key: key |> JOSE.JWK.from_key(),
+          x509: JWK.X509.new(x5c: x5c)
         }
-      )
-      |> JOSE.JWS.compact()
-      |> elem(1)
+        |> JWK.new()
 
-    jwk = JWK.X509.new_from_jws_token(jws, root_ca)
+      payload = %{"key" => "value"}
 
-    assert {:ok, payload} == JWS.verify(jws, [jwk])
+      assert {:ok, jws} = JWS.sign(payload, jwk)
+
+      assert jwk = JWK.X509.new_from_jws_token(jws, root_ca)
+
+      assert {:ok, payload} == JWS.verify(jws, [jwk])
+    end
   end
 end

--- a/test/lib/kitten_blue/jws/x509_test.exs
+++ b/test/lib/kitten_blue/jws/x509_test.exs
@@ -3,6 +3,45 @@ defmodule KittenBlue.JWS.X509Test do
 
   alias KittenBlue.{JWK, JWS}
 
+  test "sign" do
+    key = File.read!("sample_pem/rsa-2048.pem") |> X509.PrivateKey.from_pem!()
+
+    root_ca =
+      X509.Certificate.self_signed(
+        key,
+        "/C=JP/ST=Tokyo/L=Shibuya/O=Acme/CN=Root CA",
+        template: :root_ca
+      )
+
+    cert =
+      key
+      |> X509.PublicKey.derive()
+      |> X509.Certificate.new(
+        "/C=JP/ST=Tokyo/L=Shibuya/O=Acme/CN=Cert",
+        root_ca,
+        key
+      )
+
+    x5c = [cert |> X509.Certificate.to_der() |> Base.encode64()]
+
+    alg = "RS256"
+    kid = "rs256_202301"
+
+    jwk = %{
+      kid: kid,
+      alg: alg,
+      key: key |> JOSE.JWK.from_key(),
+      x509: JWK.X509.new([x5c: x5c])
+    }
+    |> JWK.new()
+
+    payload = %{"key" => "value"}
+
+    assert {:ok, jws} = JWS.sign(payload, jwk)
+
+    assert {:ok, payload} == JWS.verify(jws, [jwk])
+  end
+
   test "verify" do
     key = File.read!("sample_pem/rsa-2048.pem") |> X509.PrivateKey.from_pem!()
 


### PR DESCRIPTION
- Add an optional field to `KittenBlue.JWK` to handle X.509 parameters
  - `kid` and `alg` fields are also optional, so I'd like to discuss how to design `JWK` struct
- Implement `x5c` field to `KittenBlue.JWK.X509` to sign and verify with them
  - Add handling for verifying with ECC key
- Some refactoring
  - Use `Application.compile_env` instead of `Application.fetch_env`
