### PR TITLE
Update CI versions matrix, and suppress warnings on compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ jobs:
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
       matrix:
-        otp: ['24.3.4.7', '25.0.4', '25.1.2', '25.2']
-        elixir: ['1.13.4', '1.14.3']
+        otp: ['24.3.4.7', '25.0.4', '25.1.2', '25.2', '26.0.2']
+        elixir: ['1.13.4', '1.14.3', '1.15.2']
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.14.3
-erlang 25.3
+elixir 1.15.2
+erlang 26.0.2

--- a/lib/kitten_blue/jwk.ex
+++ b/lib/kitten_blue/jwk.ex
@@ -249,11 +249,11 @@ defmodule KittenBlue.JWK do
         Jason.decode!(body) |> __MODULE__.public_jwk_sets_to_list()
 
       {:ok, %{} = res} ->
-        Logger.warn("HTTP Client returned {:ok, #{inspect(res)}}")
+        Logger.warning("HTTP Client returned {:ok, #{inspect(res)}}")
         nil
 
       {:error, %{reason: _} = error} ->
-        Logger.warn("HTTP Client returned {:error, #{inspect(error)}}")
+        Logger.warning("HTTP Client returned {:error, #{inspect(error)}}")
         nil
     end
   end

--- a/mix.lock
+++ b/mix.lock
@@ -9,5 +9,5 @@
   "mox": {:hex, :mox, "1.0.2", "dc2057289ac478b35760ba74165b4b3f402f68803dd5aecd3bfd19c183815d64", [:mix], [], "hexpm", "f9864921b3aaf763c8741b5b8e6f908f44566f1e427b2630e89e9a73b981fef2"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "scratcher": {:hex, :scratcher, "0.1.1", "50ae0170c7564b81fc491dc8f7ed195371586df9e2f2d7981685815c2187c54b", [:mix], [], "hexpm", "0e83bef9c7f41d16bf196ca83e4798b9bf7b031fcb0ea5f4e2ba612f89352845"},
-  "x509": {:hex, :x509, "0.8.5", "22b2c5dfc87b05d46595d3764f41a23fcb7360f891e0464f1a2ec118177cd4e4", [:mix], [], "hexpm", "c63eb89e8bbe8a5e21b6404ad1082faff670e38b74960297f90d023177949e07"},
+  "x509": {:hex, :x509, "0.8.8", "aaf5e58b19a36a8e2c5c5cff0ad30f64eef5d9225f0fd98fb07912ee23f7aba3", [:mix], [], "hexpm", "ccc3bff61406e5bb6a63f06d549f3dba3a1bbb456d84517efaaa210d8a33750f"},
 }


### PR DESCRIPTION
- Update CI versions matrix, add OTP 26.0.2 and Elixir 1.15.2
  - I'll leave it to you to delete older versions.
- Use the latest versions for asdf
- Suppress warnings on compilation
  - `warning: Logger.warn/1 is deprecated. Use Logger.warning/2 instead`
- Update x509 version
  - https://github.com/voltone/x509/pull/60