### PR TITLE
remove Elixir Version 1.13, 1.14 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         otp: ['24.3.4.7', '25.0.4', '25.1.2', '25.2', '26.0.2']
-        elixir: ['1.13.4', '1.14.3', '1.15.2']
+        elixir: ['1.15.2']
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule KittenBlue.Mixfile do
     [
       app: :kitten_blue,
       version: "0.7.0",
-      elixir: "~> 1.13",
+      elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       description:


### PR DESCRIPTION
#29 had new OTP versions added to the CI matrix, but some were incompatible.

https://hexdocs.pm/elixir/compatibility-and-deprecations.html

ELIXIR VERSION | SUPPORTED ERLANG/OTP VERSIONS
-- | --
1.15 | 24 - 26
1.14 | 23 - 25
1.13 | 22 - 24 (and Erlang/OTP 25 from v1.13.4)

Remove the old Elixir version of CI in favor of the new OTP version.

