### PR TITLE
add helper module for DPoP

### DIFF
--- a/lib/kitten_blue/jwk.ex
+++ b/lib/kitten_blue/jwk.ex
@@ -293,4 +293,12 @@ defmodule KittenBlue.JWK do
       Enum.find(keys, fn kb_jwk -> kb_jwk.kid == kid end)
     end
   end
+
+  @doc """
+  Function to return JWK Thumbprint
+  """
+  @spec to_thumbprint(jwk :: t()) :: String.t()
+  def to_thumbprint(jwk) do
+    JOSE.JWK.thumbprint(:sha256, jwk.key)
+  end
 end

--- a/lib/kitten_blue/jwk.ex
+++ b/lib/kitten_blue/jwk.ex
@@ -9,13 +9,21 @@ defmodule KittenBlue.JWK do
     :kid,
     :alg,
     :key,
-    :x509 # optional
+    # optional
+    :x509
   ]
 
-  @type t :: %__MODULE__{kid: String.t(), alg: String.t(), key: JOSE.JWK.t(), x509: KittenBlue.JWK.X509.t()}
+  @type t :: %__MODULE__{
+          kid: String.t(),
+          alg: String.t(),
+          key: JOSE.JWK.t(),
+          x509: KittenBlue.JWK.X509.t()
+        }
 
   # Set the default value here to avoid compilation errors where Configuration does not exist.
-  @http_client Application.compile_env(:kitten_blue, __MODULE__, http_client: Scratcher.HttpClient)
+  @http_client Application.compile_env(:kitten_blue, __MODULE__,
+                 http_client: Scratcher.HttpClient
+               )
                |> Keyword.fetch!(:http_client)
 
   # NOTE: from_compact/to_conpact does not support Poly1305

--- a/lib/kitten_blue/jwk/x509.ex
+++ b/lib/kitten_blue/jwk/x509.ex
@@ -56,7 +56,7 @@ defmodule KittenBlue.JWK.X509 do
                 kid: kid,
                 alg: alg,
                 key: {key, key_params} |> JOSE.JWK.from_key(),
-                x509: KittenBlue.JWK.X509.new([x5c: x5c])
+                x509: KittenBlue.JWK.X509.new(x5c: x5c)
               }
               |> KittenBlue.JWK.new()
 
@@ -65,13 +65,14 @@ defmodule KittenBlue.JWK.X509 do
                 kid: kid,
                 alg: alg,
                 key: key |> JOSE.JWK.from_key(),
-                x509: KittenBlue.JWK.X509.new([x5c: x5c])
+                x509: KittenBlue.JWK.X509.new(x5c: x5c)
               }
               |> KittenBlue.JWK.new()
 
             _ ->
               {:error, :invalid_certificate}
           end
+
         _ ->
           {:error, :invalid_jws_header}
       end

--- a/lib/kitten_blue/jws/dpop.ex
+++ b/lib/kitten_blue/jws/dpop.ex
@@ -31,12 +31,12 @@ defmodule KittenBlue.JWS.DPoP do
 
   ref. https://datatracker.ietf.org/doc/html/rfc9449#section-4.2
   """
-  @spec create_dpop_proof_jwt(payload :: map, jwk :: JWK.t()) ::
+  @spec issue_dpop_proof_jwt(payload :: map, jwk :: JWK.t()) ::
           {:ok, jwt :: String.t()} | {:error, term}
-  def create_dpop_proof_jwt(payload, jwk = %JWK{}) do
+  def issue_dpop_proof_jwt(payload, jwk = %JWK{}) do
     with :ok <- validate_payload(payload),
          {:ok, header} <- create_header(jwk),
-         {:ok, jwt} <- JWS.sign(payload, jwk, header) do
+         {:ok, jwt} <- JWS.sign(payload, jwk, header, ignore_kid: true) do
       {:ok, jwt}
     end
   end

--- a/lib/kitten_blue/jws/dpop.ex
+++ b/lib/kitten_blue/jws/dpop.ex
@@ -47,14 +47,14 @@ defmodule KittenBlue.JWS.DPoP do
   ref. https://datatracker.ietf.org/doc/html/rfc9449#section-4.3
   """
   @spec verify_dpop_proof_jwt(jwt :: String.t()) ::
-          {:ok, header :: map, payload :: map} | {:error, term}
+          {:ok, header :: map, payload :: map, jwk :: JWK.t()} | {:error, term}
   def verify_dpop_proof_jwt(jwt) do
     with {:ok, payload} <- JOSE.JWS.peek_payload(jwt) |> Jason.decode(),
          :ok <- validate_payload(payload),
          {:ok, header} <- JOSE.JWS.peek_protected(jwt) |> Jason.decode(),
-         {:ok, key} <- validate_header(header),
-         {:ok, _} <- JWS.verify_without_kid(jwt, key) do
-      {:ok, payload, header}
+         {:ok, jwk} <- validate_header(header),
+         {:ok, _} <- JWS.verify_without_kid(jwt, jwk) do
+      {:ok, payload, header, jwk}
     end
   end
 

--- a/lib/kitten_blue/jws/dpop.ex
+++ b/lib/kitten_blue/jws/dpop.ex
@@ -1,0 +1,82 @@
+defmodule KittenBlue.JWS.DPoP do
+  @moduledoc """
+  This module is a helper module that supports the generation and verification of DPoP Proof JWT as defined in RFC9449.
+  """
+
+  alias KittenBlue.{JWK, JWS}
+
+  @typ "dpop+jwt"
+
+  @dpop_fixed_kid "dpop-kid"
+
+  @default_alg "ES256"
+
+  @doc """
+  Function to return the private key for a given algorithm
+
+  NOTE: move to KittenBlue.JWK
+  """
+  @spec generate_private_key(opts :: Keyword.t()) :: {:ok, jwk :: JWK} | {:error, term}
+  def generate_private_key(opts \\ []) do
+    with alg <- Keyword.get(opts, :alg, @default_alg),
+         key = %JOSE.JWK{} <- JOSE.JWS.generate_key(%{"alg" => alg}),
+         kid <- Keyword.get(opts, :kid, UUID.uuid4()),
+         jwk <- JWK.new([kid, alg, key]) do
+      {:ok, jwk}
+    end
+  end
+
+  @doc """
+  Function to create DPoP Proof JWT
+
+  ref. https://datatracker.ietf.org/doc/html/rfc9449#section-4.2
+  """
+  @spec create_dpop_proof_jwt(payload :: map, jwk :: JWK.t()) ::
+          {:ok, jwt :: String.t()} | {:error, term}
+  def create_dpop_proof_jwt(payload, jwk = %JWK{}) do
+    with :ok <- validate_payload(payload),
+         {:ok, header} <- create_header(jwk),
+         {:ok, jwt} <- JWS.sign(payload, jwk, header) do
+      {:ok, jwt}
+    end
+  end
+
+  @doc """
+  Function to verify DPoP Proof JWT's payload and signature
+
+  ref. https://datatracker.ietf.org/doc/html/rfc9449#section-4.3
+  """
+  @spec verify_dpop_proof_jwt(jwt :: String.t()) ::
+          {:ok, header :: map, payload :: map} | {:error, term}
+  def verify_dpop_proof_jwt(jwt) do
+    with {:ok, payload} <- JOSE.JWS.peek_payload(jwt) |> Jason.decode(),
+         :ok <- validate_payload(payload),
+         {:ok, header} <- JOSE.JWS.peek_protected(jwt) |> Jason.decode(),
+         {:ok, key} <- validate_header(header),
+         {:ok, _} <- JWS.verify_without_kid(jwt, key) do
+      {:ok, payload}
+    end
+  end
+
+  defp validate_payload(%{"jti" => _, "htm" => _, "htu" => _, "iat" => _, "ath" => _}), do: :ok
+  defp validate_payload(%{"jti" => _, "htm" => _, "htu" => _, "iat" => _}), do: :ok
+  defp validate_payload(_), do: {:error, :invalid_payload}
+
+  defp create_header(jwk) do
+    with pubkey <- JWK.to_public_jwk_set(jwk) |> Map.drop(["alg", "kid", "use"]) do
+      {:ok, %{"typ" => @typ, "alg" => jwk.alg, "jwk" => pubkey}}
+    end
+  end
+
+  defp validate_header(%{"typ" => @typ, "alg" => alg, "jwk" => public_key_params}) do
+    with jwk = %JWK{} <-
+           JWK.from_public_jwk_set(
+             public_key_params
+             |> Map.merge(%{"kid" => @dpop_fixed_kid, "alg" => alg})
+           ) do
+      {:ok, jwk}
+    end
+  end
+
+  defp validate_header(_), do: {:error, :invalid_header}
+end

--- a/lib/kitten_blue/jws/dpop.ex
+++ b/lib/kitten_blue/jws/dpop.ex
@@ -54,7 +54,7 @@ defmodule KittenBlue.JWS.DPoP do
          {:ok, header} <- JOSE.JWS.peek_protected(jwt) |> Jason.decode(),
          {:ok, key} <- validate_header(header),
          {:ok, _} <- JWS.verify_without_kid(jwt, key) do
-      {:ok, payload}
+      {:ok, payload, header}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -35,6 +35,7 @@ defmodule KittenBlue.Mixfile do
       {:jose, "~> 1.11"},
       {:jason, "~> 1.2", optional: true},
       {:x509, "~> 0.8"},
+      {:uuid, "~> 1.1"},
 
       # HTTP Client
       {:scratcher, "~> 0.1"},

--- a/mix.lock
+++ b/mix.lock
@@ -9,5 +9,6 @@
   "mox": {:hex, :mox, "1.0.2", "dc2057289ac478b35760ba74165b4b3f402f68803dd5aecd3bfd19c183815d64", [:mix], [], "hexpm", "f9864921b3aaf763c8741b5b8e6f908f44566f1e427b2630e89e9a73b981fef2"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "scratcher": {:hex, :scratcher, "0.1.1", "50ae0170c7564b81fc491dc8f7ed195371586df9e2f2d7981685815c2187c54b", [:mix], [], "hexpm", "0e83bef9c7f41d16bf196ca83e4798b9bf7b031fcb0ea5f4e2ba612f89352845"},
+  "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm", "c790593b4c3b601f5dc2378baae7efaf5b3d73c4c6456ba85759905be792f2ac"},
   "x509": {:hex, :x509, "0.8.8", "aaf5e58b19a36a8e2c5c5cff0ad30f64eef5d9225f0fd98fb07912ee23f7aba3", [:mix], [], "hexpm", "ccc3bff61406e5bb6a63f06d549f3dba3a1bbb456d84517efaaa210d8a33750f"},
 }

--- a/test/lib/kitten_blue/jwk_test.exs
+++ b/test/lib/kitten_blue/jwk_test.exs
@@ -361,7 +361,7 @@ defmodule KittenBlue.JWKTest do
       "kid" => "test"
     }
 
-    jwk = JWK.from_public_jwk_set(es_pubkey) |> IO.inspect()
+    jwk = JWK.from_public_jwk_set(es_pubkey)
     assert "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I" = JWK.to_thumbprint(jwk)
   end
 

--- a/test/lib/kitten_blue/jwk_test.exs
+++ b/test/lib/kitten_blue/jwk_test.exs
@@ -337,5 +337,33 @@ defmodule KittenBlue.JWKTest do
     refute JWK.find_key_to_issue(config)
   end
 
+  test "to_thumbprint" do
+    # ref. https://datatracker.ietf.org/doc/html/rfc7638#section-3.1
+    rsa_pubkey = %{
+      "kty" => "RSA",
+      "n" =>
+        "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+      "e" => "AQAB",
+      "alg" => "RS256",
+      "kid" => "2011-04-29"
+    }
+
+    jwk = JWK.from_public_jwk_set(rsa_pubkey)
+    assert "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs" = JWK.to_thumbprint(jwk)
+
+    # ref. https://datatracker.ietf.org/doc/html/rfc9449#section-6.1
+    es_pubkey = %{
+      "alg" => "ES256",
+      "crv" => "P-256",
+      "kty" => "EC",
+      "x" => "l8tFrhx-34tV3hRICRDY9zCkDlpBhF42UQUfWVAWBFs",
+      "y" => "9VE4jf_Ok_o64zbTTlcuNJajHmt6v9TDVrU0CdvGRDA",
+      "kid" => "test"
+    }
+
+    jwk = JWK.from_public_jwk_set(es_pubkey) |> IO.inspect()
+    assert "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I" = JWK.to_thumbprint(jwk)
+  end
+
   # TODO: test for fetch!()
 end

--- a/test/lib/kitten_blue/jws/dpop_test.exs
+++ b/test/lib/kitten_blue/jws/dpop_test.exs
@@ -1,8 +1,59 @@
 defmodule KittenBlue.JWS.DPoPTest do
   use ExUnit.Case
 
-  alias KittenBlue.{JWS.DPoP, JWK}
+  alias KittenBlue.{JWS, JWS.DPoP, JWK}
   doctest DPoP
+
+  test "RFC 9449" do
+    # ref. https://datatracker.ietf.org/doc/html/rfc9449#section-4.1
+    jwt =
+      "eyJ0eXAiOiJkcG9wK2p3dCIsImFsZyI6IkVTMjU2IiwiandrIjp7Imt0eSI6IkVDIiwieCI6Imw4dEZyaHgtMzR0VjNoUklDUkRZOXpDa0RscEJoRjQyVVFVZldWQVdCRnMiLCJ5IjoiOVZFNGpmX09rX282NHpiVFRsY3VOSmFqSG10NnY5VERWclUwQ2R2R1JEQSIsImNydiI6IlAtMjU2In19.eyJqdGkiOiItQndDM0VTYzZhY2MybFRjIiwiaHRtIjoiUE9TVCIsImh0dSI6Imh0dHBzOi8vc2VydmVyLmV4YW1wbGUuY29tL3Rva2VuIiwiaWF0IjoxNTYyMjYyNjE2fQ.2-GxA6T8lP4vfrg8v-FdWP0A0zdrj8igiMLvqRMUvwnQg4PtFLbdLXiOSsX0x7NVY-FNyJK70nfbV37xRZT3Lg"
+
+    assert {:ok, payload, header} = DPoP.verify_dpop_proof_jwt(jwt)
+
+    assert %{
+             "htm" => "POST",
+             "htu" => "https://server.example.com/token",
+             "iat" => 1_562_262_616,
+             "jti" => "-BwC3ESc6acc2lTc"
+           } = payload
+
+    assert %{
+             "alg" => "ES256",
+             "jwk" => %{
+               "crv" => "P-256",
+               "kty" => "EC",
+               "x" => "l8tFrhx-34tV3hRICRDY9zCkDlpBhF42UQUfWVAWBFs",
+               "y" => "9VE4jf_Ok_o64zbTTlcuNJajHmt6v9TDVrU0CdvGRDA"
+             },
+             "typ" => "dpop+jwt"
+           } = header
+
+    # ref. https://datatracker.ietf.org/doc/html/rfc9449#section-7.1
+    jwt =
+      "eyJ0eXAiOiJkcG9wK2p3dCIsImFsZyI6IkVTMjU2IiwiandrIjp7Imt0eSI6IkVDIiwieCI6Imw4dEZyaHgtMzR0VjNoUklDUkRZOXpDa0RscEJoRjQyVVFVZldWQVdCRnMiLCJ5IjoiOVZFNGpmX09rX282NHpiVFRsY3VOSmFqSG10NnY5VERWclUwQ2R2R1JEQSIsImNydiI6IlAtMjU2In19.eyJqdGkiOiJlMWozVl9iS2ljOC1MQUVCIiwiaHRtIjoiR0VUIiwiaHR1IjoiaHR0cHM6Ly9yZXNvdXJjZS5leGFtcGxlLm9yZy9wcm90ZWN0ZWRyZXNvdXJjZSIsImlhdCI6MTU2MjI2MjYxOCwiYXRoIjoiZlVIeU8ycjJaM0RaNTNFc05yV0JiMHhXWG9hTnk1OUlpS0NBcWtzbVFFbyJ9.2oW9RP35yRqzhrtNP86L-Ey71EOptxRimPPToA1plemAgR6pxHF8y6-yqyVnmcw6Fy1dqd-jfxSYoMxhAJpLjA"
+
+    assert {:ok, payload, header} = DPoP.verify_dpop_proof_jwt(jwt)
+
+    assert %{
+             "htm" => "GET",
+             "htu" => "https://resource.example.org/protectedresource",
+             "iat" => 1_562_262_618,
+             "jti" => "e1j3V_bKic8-LAEB",
+             "ath" => "fUHyO2r2Z3DZ53EsNrWBb0xWXoaNy59IiKCAqksmQEo"
+           } = payload
+
+    assert %{
+             "alg" => "ES256",
+             "jwk" => %{
+               "crv" => "P-256",
+               "kty" => "EC",
+               "x" => "l8tFrhx-34tV3hRICRDY9zCkDlpBhF42UQUfWVAWBFs",
+               "y" => "9VE4jf_Ok_o64zbTTlcuNJajHmt6v9TDVrU0CdvGRDA"
+             },
+             "typ" => "dpop+jwt"
+           } = header
+  end
 
   test "generate_jwk" do
     assert {:ok, jwk = %JWK{}} = DPoP.generate_private_key()
@@ -18,7 +69,7 @@ defmodule KittenBlue.JWS.DPoPTest do
     assert jwk.key
   end
 
-  test "issue_and_verify" do
+  test "issue" do
     assert {:ok, jwk = %JWK{}} = DPoP.generate_private_key()
 
     payload = %{
@@ -44,5 +95,52 @@ defmodule KittenBlue.JWS.DPoPTest do
            } = jwt_header
 
     assert payload == jwt_payload
+
+    assert {:error, :invalid_payload} = DPoP.issue_dpop_proof_jwt(%{}, jwk)
+  end
+
+  test "verify" do
+    assert {:ok, jwk = %JWK{}} = DPoP.generate_private_key()
+
+    payload = %{
+      "jti" => "-BwC3ESc6acc2lTc",
+      "htm" => "POST",
+      "htu" => "https://server.example.com/token",
+      "iat" => 1_562_262_616
+    }
+
+    assert {:ok, jwt} = DPoP.issue_dpop_proof_jwt(payload, jwk)
+
+    assert {:ok, payload, header} = DPoP.verify_dpop_proof_jwt(jwt)
+
+    assert %{
+             "htm" => "POST",
+             "htu" => "https://server.example.com/token",
+             "iat" => 1_562_262_616,
+             "jti" => "-BwC3ESc6acc2lTc"
+           } = payload
+
+    assert %{
+             "alg" => "ES256",
+             "jwk" => %{
+               "crv" => "P-256",
+               "kty" => "EC",
+               "x" => _,
+               "y" => _
+             },
+             "typ" => "dpop+jwt"
+           } = header
+
+    assert {:error, :invalid_jwt_signature} = DPoP.verify_dpop_proof_jwt(jwt <> "invalid")
+
+    # empty payload
+    {:ok, jwt} = JWS.sign(%{}, jwk, header, ignore_kid: true)
+
+    assert {:error, :invalid_payload} = DPoP.verify_dpop_proof_jwt(jwt)
+
+    # pubkey not found
+    {:ok, jwt} = JWS.sign(payload, jwk, %{})
+
+    assert {:error, :invalid_header} = DPoP.verify_dpop_proof_jwt(jwt)
   end
 end

--- a/test/lib/kitten_blue/jws/dpop_test.exs
+++ b/test/lib/kitten_blue/jws/dpop_test.exs
@@ -1,0 +1,48 @@
+defmodule KittenBlue.JWS.DPoPTest do
+  use ExUnit.Case
+
+  alias KittenBlue.{JWS.DPoP, JWK}
+  doctest DPoP
+
+  test "generate_jwk" do
+    assert {:ok, jwk = %JWK{}} = DPoP.generate_private_key()
+    assert jwk.alg == "ES256"
+    assert jwk.key
+
+    assert {:ok, jwk = %JWK{}} = DPoP.generate_private_key(alg: "ES256")
+    assert jwk.alg == "ES256"
+    assert jwk.key
+
+    assert {:ok, jwk = %JWK{}} = DPoP.generate_private_key(alg: "RS256")
+    assert jwk.alg == "RS256"
+    assert jwk.key
+  end
+
+  test "issue_and_verify" do
+    assert {:ok, jwk = %JWK{}} = DPoP.generate_private_key()
+
+    payload = %{
+      "jti" => "-BwC3ESc6acc2lTc",
+      "htm" => "POST",
+      "htu" => "https://server.example.com/token",
+      "iat" => 1_562_262_616
+    }
+
+    assert {:ok, jwt} = DPoP.issue_dpop_proof_jwt(payload, jwk)
+    assert {:ok, jwt_header} = JOSE.JWS.peek_protected(jwt) |> Jason.decode()
+    assert {:ok, jwt_payload} = JOSE.JWS.peek_payload(jwt) |> Jason.decode()
+
+    assert %{
+             "alg" => "ES256",
+             "typ" => "dpop+jwt",
+             "jwk" => %{
+               "crv" => "P-256",
+               "kty" => "EC",
+               "x" => _,
+               "y" => _
+             }
+           } = jwt_header
+
+    assert payload == jwt_payload
+  end
+end

--- a/test/lib/kitten_blue/jws/dpop_test.exs
+++ b/test/lib/kitten_blue/jws/dpop_test.exs
@@ -9,7 +9,7 @@ defmodule KittenBlue.JWS.DPoPTest do
     jwt =
       "eyJ0eXAiOiJkcG9wK2p3dCIsImFsZyI6IkVTMjU2IiwiandrIjp7Imt0eSI6IkVDIiwieCI6Imw4dEZyaHgtMzR0VjNoUklDUkRZOXpDa0RscEJoRjQyVVFVZldWQVdCRnMiLCJ5IjoiOVZFNGpmX09rX282NHpiVFRsY3VOSmFqSG10NnY5VERWclUwQ2R2R1JEQSIsImNydiI6IlAtMjU2In19.eyJqdGkiOiItQndDM0VTYzZhY2MybFRjIiwiaHRtIjoiUE9TVCIsImh0dSI6Imh0dHBzOi8vc2VydmVyLmV4YW1wbGUuY29tL3Rva2VuIiwiaWF0IjoxNTYyMjYyNjE2fQ.2-GxA6T8lP4vfrg8v-FdWP0A0zdrj8igiMLvqRMUvwnQg4PtFLbdLXiOSsX0x7NVY-FNyJK70nfbV37xRZT3Lg"
 
-    assert {:ok, payload, header} = DPoP.verify_dpop_proof_jwt(jwt)
+    assert {:ok, payload, header, _} = DPoP.verify_dpop_proof_jwt(jwt)
 
     assert %{
              "htm" => "POST",
@@ -33,7 +33,7 @@ defmodule KittenBlue.JWS.DPoPTest do
     jwt =
       "eyJ0eXAiOiJkcG9wK2p3dCIsImFsZyI6IkVTMjU2IiwiandrIjp7Imt0eSI6IkVDIiwieCI6Imw4dEZyaHgtMzR0VjNoUklDUkRZOXpDa0RscEJoRjQyVVFVZldWQVdCRnMiLCJ5IjoiOVZFNGpmX09rX282NHpiVFRsY3VOSmFqSG10NnY5VERWclUwQ2R2R1JEQSIsImNydiI6IlAtMjU2In19.eyJqdGkiOiJlMWozVl9iS2ljOC1MQUVCIiwiaHRtIjoiR0VUIiwiaHR1IjoiaHR0cHM6Ly9yZXNvdXJjZS5leGFtcGxlLm9yZy9wcm90ZWN0ZWRyZXNvdXJjZSIsImlhdCI6MTU2MjI2MjYxOCwiYXRoIjoiZlVIeU8ycjJaM0RaNTNFc05yV0JiMHhXWG9hTnk1OUlpS0NBcWtzbVFFbyJ9.2oW9RP35yRqzhrtNP86L-Ey71EOptxRimPPToA1plemAgR6pxHF8y6-yqyVnmcw6Fy1dqd-jfxSYoMxhAJpLjA"
 
-    assert {:ok, payload, header} = DPoP.verify_dpop_proof_jwt(jwt)
+    assert {:ok, payload, header, _} = DPoP.verify_dpop_proof_jwt(jwt)
 
     assert %{
              "htm" => "GET",
@@ -111,7 +111,9 @@ defmodule KittenBlue.JWS.DPoPTest do
 
     assert {:ok, jwt} = DPoP.issue_dpop_proof_jwt(payload, jwk)
 
-    assert {:ok, payload, header} = DPoP.verify_dpop_proof_jwt(jwt)
+    assert {:ok, payload, header, decode_jwk} = DPoP.verify_dpop_proof_jwt(jwt)
+
+    assert JWK.to_thumbprint(jwk) == JWK.to_thumbprint(decode_jwk)
 
     assert %{
              "htm" => "POST",

--- a/test/lib/kitten_blue/jws_test.exs
+++ b/test/lib/kitten_blue/jws_test.exs
@@ -13,6 +13,7 @@ defmodule KittenBlue.JWSTest do
                    |> JOSE.JWK.from_oct()
                ]
                |> JWK.new()
+
   @hs256_jwk_2 [
                  kid: "hs256_second",
                  alg: "HS256",
@@ -22,6 +23,7 @@ defmodule KittenBlue.JWSTest do
                    |> JOSE.JWK.from_oct()
                ]
                |> JWK.new()
+
   @hs256_jwk_3 [
                  kid: @hs256_jwk_1.kid,
                  alg: @hs256_jwk_1.alg,
@@ -65,6 +67,7 @@ defmodule KittenBlue.JWSTest do
                    |> JOSE.JWK.from_pem()
                ]
                |> JWK.new()
+
   @rs256_jwk_2 [
                  kid: "rs256_second",
                  alg: "RS256",
@@ -133,6 +136,16 @@ defmodule KittenBlue.JWSTest do
       assert {:ok, jws} = JWS.sign(payload, @rs256_jwk_1, header)
       assert {:ok, payload} == JWS.verify(jws, [@rs256_jwk_1, @rs256_jwk_2])
       assert {:ok, payload} == JWS.verify(jws, [@rs256_jwk_1, @rs256_jwk_2], header)
+    end
+
+    test "ignore kid" do
+      payload = %{"foo" => "var"}
+      assert {:ok, jws} = JWS.sign(payload, @rs256_jwk_1, %{}, ignore_kid: true)
+      assert {:ok, %{"alg" => "RS256", "typ" => "JWT"}} == JOSE.JWS.peek_protected(jws) |> Jason.decode()
+
+      assert {:ok, payload} == JWS.verify_without_kid(jws, @rs256_jwk_1)
+      assert {:error, :invalid_jwt_signature} == JWS.verify_without_kid(jws, @rs256_jwk_2)
+      assert {:error, :invalid_jwt_format} == JWS.verify(jws, [@rs256_jwk_1, @rs256_jwk_2])
     end
   end
 


### PR DESCRIPTION
Added a module to generate and validate JWT for use in DPoP.
Previously, the kid was required to generate and validate JWS, but this restriction has been relaxed.