### PR TITLE
Introduces compatibility updates for Erlang/OTP 28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,27 +12,27 @@ jobs:
         include:
           # Elixir 1.15.x with supported OTP versions
           - elixir: '1.15.8'
-            otp: '24.3'
+            otp: '24.3.4.17'
           - elixir: '1.15.8'
-            otp: '26.2'
+            otp: '26.2.5.14'
 
           # Elixir 1.16.x with supported OTP versions
           - elixir: '1.16.3'
-            otp: '24.3'
+            otp: '24.3.4.17'
           - elixir: '1.16.3'
-            otp: '26.2'
+            otp: '26.2.5.14'
 
           # Elixir 1.17.x with supported OTP versions
           - elixir: '1.17.3'
-            otp: '25.3'
+            otp: '25.3.2.21'
           - elixir: '1.17.3'
-            otp: '27.1'
+            otp: '27.3.4.2'
 
           # Elixir 1.18.x with supported OTP versions (including OTP 28)
           - elixir: '1.18.4'
-            otp: '25.3'
+            otp: '25.3.2.21'
           - elixir: '1.18.4'
-            otp: '28.0'
+            otp: '28.0.2'
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,34 @@ jobs:
     runs-on: ubuntu-latest
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
+      fail-fast: false
       matrix:
-        otp: ['24.3.4.7', '25.0.4', '25.1.2', '25.2', '26.0.2']
-        elixir: ['1.15.2']
+        include:
+          # Elixir 1.15.x with supported OTP versions
+          - elixir: '1.15.8'
+            otp: '24.3'
+          - elixir: '1.15.8'
+            otp: '26.2'
+
+          # Elixir 1.16.x with supported OTP versions
+          - elixir: '1.16.3'
+            otp: '24.3'
+          - elixir: '1.16.3'
+            otp: '26.2'
+
+          # Elixir 1.17.x with supported OTP versions
+          - elixir: '1.17.3'
+            otp: '25.3'
+          - elixir: '1.17.3'
+            otp: '27.1'
+
+          # Elixir 1.18.x with supported OTP versions (including OTP 28)
+          - elixir: '1.18.4'
+            otp: '25.3'
+          - elixir: '1.18.4'
+            otp: '28.0'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
-on: push
+on:
+  push:
+  pull_request:
 
 jobs:
   test:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.15.2
-erlang 26.0.2
+elixir 1.18.4-otp-28
+erlang 28.0.2

--- a/mix.lock
+++ b/mix.lock
@@ -10,5 +10,5 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "scratcher": {:hex, :scratcher, "0.1.1", "50ae0170c7564b81fc491dc8f7ed195371586df9e2f2d7981685815c2187c54b", [:mix], [], "hexpm", "0e83bef9c7f41d16bf196ca83e4798b9bf7b031fcb0ea5f4e2ba612f89352845"},
   "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm", "c790593b4c3b601f5dc2378baae7efaf5b3d73c4c6456ba85759905be792f2ac"},
-  "x509": {:hex, :x509, "0.8.8", "aaf5e58b19a36a8e2c5c5cff0ad30f64eef5d9225f0fd98fb07912ee23f7aba3", [:mix], [], "hexpm", "ccc3bff61406e5bb6a63f06d549f3dba3a1bbb456d84517efaaa210d8a33750f"},
+  "x509": {:hex, :x509, "0.9.2", "a75aa605348abd905990f3d2dc1b155fcde4e030fa2f90c4a91534405dce0f6e", [:mix], [], "hexpm", "4c5ede75697e565d4b0f5be04c3b71bb1fd3a090ea243af4bd7dae144e48cfc7"},
 }

--- a/test/lib/kitten_blue/jwk_test.exs
+++ b/test/lib/kitten_blue/jwk_test.exs
@@ -220,24 +220,26 @@ defmodule KittenBlue.JWKTest do
     # ES256 with pem
     es_compact = JWK.to_compact(jwk_es256)
     assert [kid_es256, alg_es256, key_es256 |> JOSE.JWK.to_pem() |> elem(1)] == es_compact
-    assert jwk_es256 == JWK.from_compact(es_compact)
+    # PEM round trip changes internal key format, so compare the converted version
+    expected_jwk = %{jwk_es256 | key: KittenBlue.JWK.convert_key_version_jose(jwk_es256.key)}
+    assert expected_jwk == JWK.from_compact(es_compact)
     es_compact_list = JWK.list_to_compact([jwk_es256])
     assert [[kid_es256, alg_es256, key_es256 |> JOSE.JWK.to_pem() |> elem(1)]] == es_compact_list
-    assert [jwk_es256] == JWK.compact_to_list(es_compact_list)
+    assert [expected_jwk] == JWK.compact_to_list(es_compact_list)
 
     # ES256 with map
     es_compact_with_map = JWK.to_compact(jwk_es256, use_map: true)
 
-    assert [kid_es256, alg_es256, key_es256 |> JOSE.JWK.to_map() |> elem(1)] ==
+    assert [kid_es256, alg_es256, key_es256 |> KittenBlue.JWK.convert_key_version_jose() |> JOSE.JWK.to_map() |> elem(1)] ==
              es_compact_with_map
 
-    assert jwk_es256 == JWK.from_compact(es_compact_with_map)
+    assert expected_jwk == JWK.from_compact(es_compact_with_map)
     es_compact_list_with_map = JWK.list_to_compact([jwk_es256], use_map: true)
 
-    assert [[kid_es256, alg_es256, key_es256 |> JOSE.JWK.to_map() |> elem(1)]] ==
+    assert [[kid_es256, alg_es256, key_es256 |> KittenBlue.JWK.convert_key_version_jose() |> JOSE.JWK.to_map() |> elem(1)]] ==
              es_compact_list_with_map
 
-    assert [jwk_es256] == JWK.compact_to_list(es_compact_list_with_map)
+    assert [expected_jwk] == JWK.compact_to_list(es_compact_list_with_map)
   end
 
   test "Ed25519" do


### PR DESCRIPTION
This pull request introduces compatibility updates for Erlang/OTP 28, refactors the JWK handling logic, and updates the CI configuration to test against newer versions of Elixir and OTP. The most important changes include adding a conversion function for JWK compatibility with OTP 28, updating the CI matrix to include additional Elixir and OTP versions, and refactoring the JWK generation and validation logic.

### Compatibility with OTP 28:

* Added a new function `convert_key_version_jose/1` in `lib/kitten_blue/jwk.ex` to handle JWK format compatibility issues with OTP 28. This includes a private helper function `do_convert_key_version_jose/1` to adjust the key format for unsupported versions of the JOSE library.
* Updated all relevant JWK functions (`to_public_jwk_set`, `from_compact`, `to_compact`, etc.) to use the new conversion function for compatibility. [[1]](diffhunk://#diff-64a14d074271127219a232eda45650fe0a3ed9b65ac96c1d2fae4315e22a4b3aR105) [[2]](diffhunk://#diff-64a14d074271127219a232eda45650fe0a3ed9b65ac96c1d2fae4315e22a4b3aL147-R148) [[3]](diffhunk://#diff-64a14d074271127219a232eda45650fe0a3ed9b65ac96c1d2fae4315e22a4b3aL186-R187) [[4]](diffhunk://#diff-64a14d074271127219a232eda45650fe0a3ed9b65ac96c1d2fae4315e22a4b3aL228-R235)

### CI Configuration Updates:

* Updated `.github/workflows/ci.yml` to expand the testing matrix with additional Elixir and OTP versions, including Elixir 1.15.x through 1.18.x and OTP versions 24 through 28.
* Changed the checkout action in CI from `actions/checkout@v2` to `actions/checkout@v4` for better compatibility and performance.

### JWK Handling Refactor:

* Introduced a helper function `generate_jwk_for_alg/1` in `lib/kitten_blue/jws/dpop.ex` to streamline the creation of JWKs for different algorithms.
* Updated the `generate_private_key` function in `lib/kitten_blue/jws/dpop.ex` to use `generate_jwk_for_alg/1` and apply the new conversion function for OTP 28 compatibility.

### Dependency Updates:

* Updated `.tool-versions` to use Elixir 1.18.4-otp-28 and Erlang 28.0.2, aligning the project with the latest supported versions.

### Test Adjustments:

* Modified `test/lib/kitten_blue/jwk_test.exs` to account for the new JWK conversion logic, ensuring tests compare converted keys where necessary.